### PR TITLE
chore: add start script to preview app on port 8080

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "vite preview --port 8080",
     "build": "tsc && vite build",
     "deploy": "s3-spa-upload --cache-control-mapping cache-control.json --delete dist",
     "preview": "vite preview",


### PR DESCRIPTION
The start script is added to simplify the process of previewing the built application on a specific port, enhancing developer experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Introduced a new command to launch the application preview on a specific port, streamlining the preview process for development and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->